### PR TITLE
Add Makefile and Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 top-1m.csv
 goflyway.exe
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.8.3 as build
+COPY . /build
+WORKDIR /build
+RUN CGO_ENABLED=0 make build
+ENTRYPOINT ["bash"]
+
+FROM scratch
+COPY --from=build /build/build/goflyway /goflyway
+EXPOSE 8102 8100 8101
+ENTRYPOINT ["/goflyway"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+IMAGE_NAME?=coyove/goflyway
+
+.PHONY: clean
+clean:
+	$(RM) -r build
+
+build: build/goflyway
+
+build/goflyway:
+	mkdir -p build
+	go build -o $@ main.go
+
+.PHONY: build_image
+build_image:
+	docker build -t $(IMAGE_NAME) .

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -1,0 +1,11 @@
+DOCKER_IMAGE=golang:1.8.3
+DOCKER_RUN=docker run --rm -v "$(CURDIR)":/v -w /v $(DOCKER_IMAGE)
+
+clean:
+	$(DOCKER_RUN) make $@
+
+build:
+	$(DOCKER_RUN) make $@
+
+build/goflyway:
+	$(DOCKER_RUN) make $@

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,49 @@ There is a simple web console built inside goflyway: `http://127.0.0.1:8100/?gof
 
 ![](https://github.com/coyove/goflyway/blob/master/.misc/console.png?raw=true)
 
+# Building instructions:
+Building can now be done with:
+```shell
+make clean build
+```
+
+Or if you want to do it through Docker (if you don't have/want go installed on your local):
+```shell
+make -f docker.Makefile clean build
+```
+
+# Usage as a docker image:
+Docker image can be built with:
+```shell
+make build_image
+```
+
+It's a multi-stage build so the size is ~8.23mb
+```
+❯ docker images | grep goflyway
+coyove/goflyway                      latest                       68bd9fe5612e        7 minutes ago       8.23MB
+```
+
+Can be used like:
+
+```
+❯ docker run --rm -p 8102:8102 -p 8100:8100 -p 8101:8101 coyove/goflyway -debug
+     __//                   __ _
+    /.__.\                 / _| |
+    \ \/ /      __ _  ___ | |_| |_   ___      ____ _ _   _
+ '__/    \     / _' |/ _ \|  _| | | | \ \ /\ / / _' | | | |
+  \-      )   | (_| | (_) | | | | |_| |\ V  V / (_| | |_| |
+   \_____/     \__, |\___/|_| |_|\__, | \_/\_/ \__,_|\__, |
+ ____|_|____    __/ |             __/ |               __/ |
+     " "  cf   |___/             |___/               |___/
+
+[W 0912 22:44:16.696] [WARNING] you are using the default key, please change it by setting -k=KEY
+[  0912 22:44:16.696] debug mode on, port 8100 for local redirection, upstream on 8101
+[  0912 22:44:16.696] listening on :8102
+[  0912 22:44:16.697] socks5 proxy at :8101
+[  0912 22:44:16.697] http proxy at :8100, upstream is 127.0.0.1:8101
+```
+
 ## Others
 When comes to speed, goflyway is nearly identical to shadowsocks. But HTTP has (quite large) overheads and goflyway will hardly be faster than those solutions running on their own protocols. (If your ISP deploys QoS, maybe goflyway gets some kinda faster.)
 


### PR DESCRIPTION
Adds a way to easily build / deploy goflyway using Docker.

# Building instructions:
Building can now be done with:
```shell
make clean build
```

Or if you want to do it through Docker (if you don't have/want go installed on your local):
```shell
make -f docker.Makefile clean build
```

# Usage as a docker image:
Docker image can be built with:
```shell
make build_image
```

It's a multi-stage build so the size is ~8.23mb
```
❯ docker images | grep goflyway
coyove/goflyway                      latest                       68bd9fe5612e        7 minutes ago       8.23MB
```

Can be used like:

```
❯ docker run --rm -p 8102:8102 -p 8100:8100 -p 8101:8101 coyove/goflyway -debug
     __//                   __ _
    /.__.\                 / _| |
    \ \/ /      __ _  ___ | |_| |_   ___      ____ _ _   _
 '__/    \     / _' |/ _ \|  _| | | | \ \ /\ / / _' | | | |
  \-      )   | (_| | (_) | | | | |_| |\ V  V / (_| | |_| |
   \_____/     \__, |\___/|_| |_|\__, | \_/\_/ \__,_|\__, |
 ____|_|____    __/ |             __/ |               __/ |
     " "  cf   |___/             |___/               |___/

[W 0912 22:44:16.696] [WARNING] you are using the default key, please change it by setting -k=KEY
[  0912 22:44:16.696] debug mode on, port 8100 for local redirection, upstream on 8101
[  0912 22:44:16.696] listening on :8102
[  0912 22:44:16.697] socks5 proxy at :8101
[  0912 22:44:16.697] http proxy at :8100, upstream is 127.0.0.1:8101
```