### PR TITLE
proxy: fix type switch case order

### DIFF
--- a/proxy/io.go
+++ b/proxy/io.go
@@ -129,11 +129,11 @@ REPEAT:
 		goto REPEAT
 	case *udpBridgeConn:
 		srcConn = src.(*udpBridgeConn)
-	case net.Conn:
-		srcConn = src.(net.Conn)
 	case *tcpmux.Stream:
 		// Stream has its own management of timeout
 		return
+	case net.Conn:
+		srcConn = src.(net.Conn)
 	default:
 		return
 	}


### PR DESCRIPTION
Type switch cases matched sequentially, one after
another, so concrete types should go before
interfaces they implement, otherwise
their bodies will be never executed.

Found using https://go-critic.github.io/overview#caseOrder-ref