### PR TITLE
use type switch var binding to avoid excessive type assertions

### DIFF
--- a/cmd/goflyway/main.go
+++ b/cmd/goflyway/main.go
@@ -130,13 +130,13 @@ func loadConfig() {
 	lib.Println("reading config section:", *cmdSection)
 	func(args ...interface{}) {
 		for i := 0; i < len(args); i += 2 {
-			switch f, name := args[i+1], strings.TrimSpace(args[i].(string)); f.(type) {
+			switch f, name := args[i+1], strings.TrimSpace(args[i].(string)); f := f.(type) {
 			case *string:
-				*f.(*string) = cf.GetString(*cmdSection, name, *f.(*string))
+				*f = cf.GetString(*cmdSection, name, *f)
 			case *int64:
-				*f.(*int64) = cf.GetInt(*cmdSection, name, *f.(*int64))
+				*f = cf.GetInt(*cmdSection, name, *f)
 			case *bool:
-				*f.(*bool) = cf.GetBool(*cmdSection, name, *f.(*bool))
+				*f = cf.GetBool(*cmdSection, name, *f)
 			}
 		}
 	}(

--- a/pkg/aclrouter/util.go
+++ b/pkg/aclrouter/util.go
@@ -146,11 +146,11 @@ func (lk *lookup) Match(domain string) bool {
 			return slowMatch()
 		}
 
-		switch top[sub].(type) {
+		switch sub := top[sub].(type) {
 		case matchTree:
-			top = top[sub].(matchTree)
+			top = sub
 		case int:
-			return top[sub].(int) == 0
+			return sub == 0
 		default:
 			return slowMatch()
 		}

--- a/pkg/logg/logg.go
+++ b/pkg/logg/logg.go
@@ -55,11 +55,10 @@ func GetLevel() int {
 }
 
 func Redirect(dst interface{}) {
-	switch dst.(type) {
+	switch fn := dst.(type) {
 	case func(int64, string):
-		logCallback = dst.(func(int64, string))
+		logCallback = fn
 	case string:
-		fn := dst.(string)
 		if fn[0] == '*' {
 			fn = fn[1:]
 			logFileOnly = false
@@ -134,22 +133,18 @@ func print(l string, params ...interface{}) {
 	m := msg_t{lead: fmt.Sprintf("[%s%s:%s(%d)] ", l, timestamp(), trunc(fn), line), ts: time.Now().UnixNano()}
 
 	for _, p := range params {
-		switch p.(type) {
+		switch op := p.(type) {
 		case *net.OpError:
-			op := p.(*net.OpError)
-
 			if op.Source == nil && op.Addr == nil {
-				m.message += fmt.Sprintf("%s, %s", op.Op, tryShortenWSAError(p))
+				m.message += fmt.Sprintf("%s, %s", op.Op, tryShortenWSAError(op))
 			} else {
-				m.message += fmt.Sprintf("%s %v, %s", op.Op, op.Addr, tryShortenWSAError(p))
+				m.message += fmt.Sprintf("%s %v, %s", op.Op, op.Addr, tryShortenWSAError(op))
 
 				if op.Source != nil && op.Addr != nil {
 					m.dst, _, _ = net.SplitHostPort(op.Addr.String())
 				}
 			}
 		case *net.DNSError:
-			op := p.(*net.DNSError)
-
 			if m.message += fmt.Sprintf("DNS lookup err"); op.IsTimeout {
 				m.message += ", timed out"
 			}
@@ -160,7 +155,7 @@ func print(l string, params ...interface{}) {
 				m.message += ", but with an empty name (?)"
 			}
 		default:
-			m.message += fmt.Sprintf("%+v", p)
+			m.message += fmt.Sprintf("%+v", op)
 		}
 	}
 


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#typeSwitchVar-ref