### PR TITLE
proxy: remove commented-out code from io.go

### DIFF
--- a/proxy/io.go
+++ b/proxy/io.go
@@ -164,7 +164,6 @@ func (iot *io_t) StartPurgeConns(maxIdleTime int) {
 
 	go func() {
 		count := 0
-		// lastSent, lastRecved := uint64(0), uint64(0)
 
 		for tick := range time.Tick(time.Second) {
 			iot.Lock()
@@ -341,10 +340,7 @@ func (iot *io_t) Copy(dst io.Writer, src io.Reader, key *[ivLen]byte, config IOC
 				iot.Tr.Recv(int64(nr))
 			}
 
-			if config.Partial && encrypted == sslRecordLen {
-				// goto direct_transmission
-			} else if ctr != nil {
-
+			if ctr != nil {
 				if encrypted+nr > sslRecordLen && config.Partial {
 					ybuf := xbuf[:sslRecordLen-encrypted]
 					ctr.XORKeyStream(ybuf, ybuf)


### PR DESCRIPTION
direct_transmission label does not exist,
so commented-out code only brings confusing.
Remove containing if statement as well.

Found using https://go-critic.github.io/overview#commentedOutCode-ref