### PR TITLE
proxy: fix case order in a type switch

### DIFF
--- a/proxy/io.go
+++ b/proxy/io.go
@@ -128,11 +128,11 @@ REPEAT:
 		goto REPEAT
 	case *udpBridgeConn:
 		srcConn = src.(*udpBridgeConn)
-	case net.Conn:
-		srcConn = src.(net.Conn)
 	case *tcpmux.Stream:
 		// Stream has its own management of timeout
 		return
+	case net.Conn:
+		srcConn = src.(net.Conn)
 	default:
 		return
 	}


### PR DESCRIPTION
Type switch executes its clauses sequentially until the first match.
The `*tcpmux.Stream` type implements `net.Conn`, so if `net.Conn` goes
before `*tcpmux.Stream` case, it will catch `*tcpmux.Stream` values and will
never let `case `*tcpmux.Stream` to execute. The solution is simple, move
specific type case before the interface it implements.

Found using gocritic linter, `caseOrder` checker.